### PR TITLE
Deep merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3227,6 +3227,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
+      "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser-dynamic": "^6.0.0",
     "@ngx-translate/core": ">=10.0.0",
     "core-js": "^2.5.4",
+    "deepmerge": "^2.1.1",
     "rxjs": "^6.1.0",
     "zone.js": "^0.8.26"
   },

--- a/projects/ngx-translate/multi-http-loader/src/lib/multi-http-loader.ts
+++ b/projects/ngx-translate/multi-http-loader/src/lib/multi-http-loader.ts
@@ -2,6 +2,7 @@ import {HttpClient} from "@angular/common/http";
 import {TranslateLoader} from "@ngx-translate/core";
 import {Observable, forkJoin} from "rxjs";
 import {map} from "rxjs/operators";
+import merge from 'deepmerge';
 
 
 export interface ITranslationResource {
@@ -19,6 +20,6 @@ export class MultiTranslateHttpLoader implements TranslateLoader {
     const requests = this.resources.map(resource => {
       return this.http.get(resource.prefix + lang + resource.suffix);
     });
-    return forkJoin(requests).pipe(map(response => response.reduce((a, b) => Object.assign(a, b))));
+    return forkJoin(requests).pipe(map(response => merge.all(response)));
   }
 }

--- a/projects/ngx-translate/multi-http-loader/tests/multi-http-loader.spec.ts
+++ b/projects/ngx-translate/multi-http-loader/tests/multi-http-loader.spec.ts
@@ -151,11 +151,17 @@ describe('MultiTranslateHttpLoader - Multiple Translation Files', () => {
     // mock response after the xhr request, otherwise it will be undefined
     http.expectOne('/assets/i18n/core/en.json').flush({
       "TEST": "This is a test (core)",
-      "TEST2": "This is another test (core)"
+      "TEST2": "This is another test (core)",
+      "DEEP": {
+        "some": "thing"
+      }
     });
     http.expectOne('/assets/i18n/shared/en.json').flush({
       "TEST-SHARED": "This is a test (shared)",
-      "TEST2-SHARED": "This is another test (shared)"
+      "TEST2-SHARED": "This is another test (shared)",
+      "DEEP": {
+        "another": "something"
+      }
     });
 
     // this will request the translation from downloaded translations without making a request to the backend
@@ -164,6 +170,12 @@ describe('MultiTranslateHttpLoader - Multiple Translation Files', () => {
     });
     translate.get('TEST2-SHARED').subscribe((res: string) => {
       expect(res).toEqual('This is another test (shared)');
+    });
+    translate.get('DEEP').subscribe((res: any) => {
+      expect(res).toEqual({
+        "some": "thing",
+        "another": "something"
+      });
     });
   });
 });


### PR DESCRIPTION
Currently, having the same key in multiple json files doesn't merge them together. The value from last object having a shared key will be used and will overwrite the values from the other objects under the same key.

This pull request changes this by relying on [deepmerge](https://github.com/KyleAMathews/deepmerge) to deeply merge the objects together so that the same key can exist in multiple json files.

Example:

#### core/en.json
```javascript
{
  'key1': 'something',
  'key2:' {
    'another': 'thing'
  }
}
```

#### addons/en.json
```javascript
{
  'key2': {
    'and': 'this'
  }
}
```

will result in:

```javascript
{
  'key1': 'something',
  'key2: {
    'another': 'thing',
    'and': 'this'
  }
}
```