### PR TITLE
Fixes

### DIFF
--- a/projects/multi-http-loader/src/lib/multi-http-loader.ts
+++ b/projects/multi-http-loader/src/lib/multi-http-loader.ts
@@ -20,7 +20,7 @@ export class MultiTranslateHttpLoader implements TranslateLoader {
       let path: string
 
       if (typeof resource === 'string') path = `${resource}${lang}.json`
-      else path = `${resource.prefix}${lang}${resource.suffix || '.json'}`
+      else path = `${resource.prefix}${lang}${resource.suffix ?? '.json'}`
 
       return new HttpClient(this._handler).get(path).pipe(
         catchError((res) => {

--- a/projects/multi-http-loader/src/lib/multi-http-loader.ts
+++ b/projects/multi-http-loader/src/lib/multi-http-loader.ts
@@ -12,7 +12,7 @@ export interface TranslationResource {
 export class MultiTranslateHttpLoader implements TranslateLoader {
   constructor(
     private _handler: HttpBackend,
-    private _resourcesPrefix: string[] | TranslationResource[],
+    private _resourcesPrefix: (string | TranslationResource)[],
   ) {}
 
   public getTranslation(lang: string): Observable<any> {


### PR DESCRIPTION
* was loading `*.json` when `suffix: ''`
![изображение](https://github.com/user-attachments/assets/82568378-b829-4423-95b1-b87c908cef61)
* allow mixing strings and `TranslationResource`s in the same array